### PR TITLE
Version 6 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,21 @@
 FROM ubuntu:bionic
 
-RUN apt-get update -q && apt-get install -qy software-properties-common rsync mount tar sudo systemd iputils-ping netcat iproute2
-RUN find /etc/systemd/system -type l -delete && find /lib/systemd/system/multi-user.target.wants -type l -delete && find /lib/systemd/system/sysinit.target.wants -type l -delete
-RUN add-apt-repository ppa:gluster/glusterfs-6 && apt-get update -q && apt-get install -qy glusterfs-server
+RUN apt-get update -q && \
+  DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -qy
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  software-properties-common \
+  rsync \
+  mount \
+  tar \
+  sudo \
+  iputils-ping \
+  netcat \
+  iproute2
+RUN add-apt-repository ppa:gluster/glusterfs-6 && \
+  apt-get update -q && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -qy \
+  glusterfs-server
 
 EXPOSE 2222 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
 
-CMD /sbin/init
+CMD ["/usr/sbin/glusterd","--no-daemon","--log-level=INFO","--log-file=/dev/stdout"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+When a new Gluster is released.
+
+- Retag the relevant branches with the new tags.
+- Push the new tags.
+- Check a rebuild has been triggered on quay.io for the new tags.
+- The 'master' branch is the latest gluster (currently v6).
+


### PR DESCRIPTION
The master branch is the current version of gluster. 

This version of the Dockerfile is for use with the DaemonSet from the examples directory in the kubernetes-cluster builder

